### PR TITLE
Update to use latest snapcraft features

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,0 @@
-all:
-
-install:
-	wget https://downloads.plex.tv/plex-media-server/1.2.2.2857-d34b464/plexmediaserver_1.2.2.2857-d34b464_amd64.deb -O plexmediaserver.deb
-	dpkg-deb -x plexmediaserver.deb $(DESTDIR)

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: plexmediaserver
-version: 1.2.2.2857-d34b464-1
+version: 1.2.2.2857-d34b464
 summary: Unofficial snap for the Plex media server
 architectures: [amd64]
 description: |
@@ -20,9 +20,9 @@ apps:
 parts:
   common:
     plugin: dump
-    source: .
-    snap:
-      - bin/server.sh
+    source: bin
+    organize:
+      server.sh: bin/server.sh
   plexmediaserver:
-    plugin: make
-    source: .
+    plugin: dump
+    source: https://downloads.plex.tv/plex-media-server/$SNAPCRAFT_PROJECT_VERSION/plexmediaserver_$SNAPCRAFT_PROJECT_VERSION_amd64.deb

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,5 +1,5 @@
-name: plexmediaserver
-version: 1.2.2.2857-d34b464
+name: plex-mediaserver
+version: 1.2.2.2857-d34b464-1
 summary: Unofficial snap for the Plex media server
 architectures: [amd64]
 description: |
@@ -25,4 +25,4 @@ parts:
       server.sh: bin/server.sh
   plexmediaserver:
     plugin: dump
-    source: https://downloads.plex.tv/plex-media-server/$SNAPCRAFT_PROJECT_VERSION/plexmediaserver_$SNAPCRAFT_PROJECT_VERSION_amd64.deb
+    source: https://downloads.plex.tv/plex-media-server/1.2.2.2857-d34b464/plexmediaserver_1.2.2.2857-d34b464_amd64.deb


### PR DESCRIPTION
Snapcraft now supports debs as sources so there is no need
to wrap around with a `Makefile`.

Additionally, it is better to just dump the directory we want
with the wrapper and use `organize` to make it land in the desired
location.

Signed-off-by: Sergio Schvezov <sergio.schvezov@ubuntu.com>